### PR TITLE
Link to elm-format for elm 0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Getting Started
 
 2. Add a plugin for your editor of choice: [Atom](https://atom.io/packages/language-elm), [Sublime Text](https://packagecontrol.io/packages/Elm%20Language%20Support), [VS Code](https://github.com/sbrink/vscode-elm), [Light Table](https://github.com/rundis/elm-light), [Vim](https://github.com/lambdatoast/elm.vim), [Emacs](https://github.com/jcollard/elm-mode), [Brackets](https://github.com/lepinay/elm-brackets)
 
-3. Not required, but **highly** recommended: [install elm-format](https://github.com/avh4/elm-format#installation-) and integrate it into your editor so that it runs on save. You want the one [for Elm 0.17](https://github.com/avh4/elm-format#for-elm-017).
+3. Not required, but **highly** recommended: [install elm-format](https://github.com/avh4/elm-format#installation-) and integrate it into your editor so that it runs on save. You want the one [for Elm 0.18](https://github.com/avh4/elm-format#for-elm-018).
+
 
 4. Run the following command to install everything else:
 


### PR DESCRIPTION
Since you have updated the code to be elm 0.18, let's point to the new version of elm-format :)
I'm sure this just slipped under your radar, but here you go.