### PR TITLE
Update CSS compiler to match latest ElmCSS docs

### DIFF
--- a/part13/Stylesheets.elm
+++ b/part13/Stylesheets.elm
@@ -13,11 +13,6 @@ cssFiles =
     toFileStructure [ ( "style.css", compile [ ElmHubCss.css ] ) ]
 
 
-main : Program Never Model Msg
+main : CssCompilerProgram
 main =
-    Html.program
-        { init = ( (), files cssFiles )
-        , view = \_ -> (div [] [])
-        , update = \_ _ -> ( (), Cmd.none )
-        , subscriptions = \_ -> Sub.none
-        }
+    Css.File.compiler files cssFiles


### PR DESCRIPTION
I get the following errors when I run `elm-css Stylesheets.elm` before making any changes in tutorial part13:

```
-- NAMING ERROR ------------------------------------------------ Stylesheets.elm

Cannot find type `Model`

16| main : Program Never Model Msg
                         ^^^^^


-- NAMING ERROR ------------------------------------------------ Stylesheets.elm

Cannot find type `Msg`

16| main : Program Never Model Msg
                               ^^^


Detected errors in 1 module.                                        
Error: Errored with exit code 1
```

If I update Stylesheets.elm to match the ElmCss docs (special module in "Approach 2"), it works fine.